### PR TITLE
Update LC 346: Moving Average: Add unit tests

### DIFF
--- a/tests/test_lc_346_mov_avg.c
+++ b/tests/test_lc_346_mov_avg.c
@@ -1,0 +1,27 @@
+#include <unity.h>
+#include "lc_346_mov_avg.c"
+
+
+void setUp()
+{
+
+}
+
+void tearDown()
+{
+
+}
+
+void test_MovingAverageCreate()
+{
+    //Test 1
+    int input[] = {3,1,10,3,5};
+
+    struct MovingAverage* my_ma = movingAverageCreate(input[0]);
+
+    TEST_ASSERT (movingAverageNext(my_ma, input[1]) == 1.0);
+    TEST_ASSERT (movingAverageNext(my_ma, input[2]) == 5.5);
+    TEST_ASSERT (movingAverageNext(my_ma, input[3]) == 4.666666666666667);
+    TEST_ASSERT (movingAverageNext(my_ma, input[4]) == 6.0);
+
+}


### PR DESCRIPTION
Adding C unit tests. Not running into linking errors while running the unit tests at this time. Not sure why it's an issue then but its not now.